### PR TITLE
Fix expands logic and ignore 404 and thrown exceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 
 subprojects {
 
-  version = '2.0.21'
+  version = '2.0.22'
 
   apply from: "${rootDir}/gradle/java.gradle"
   apply from: "${rootDir}/gradle/groovy.gradle"

--- a/gradle-plugin/src/main/groovy/ch/silviowangler/gradle/restapi/RestApiPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/ch/silviowangler/gradle/restapi/RestApiPlugin.groovy
@@ -74,7 +74,7 @@ class RestApiPlugin implements Plugin<Project> {
 		}
 
 		final String springVersion = "5.1.3.RELEASE"
-		final String pluginVersion = "2.0.21"
+		final String pluginVersion = "2.0.22"
 		final String libPhoneNumberVersion = "8.10.12"
 
 		project.afterEvaluate {

--- a/rest-api-micronaut/src/main/java/ch/silviowangler/rest/micronaut/ExpandedGetResponseFilter.java
+++ b/rest-api-micronaut/src/main/java/ch/silviowangler/rest/micronaut/ExpandedGetResponseFilter.java
@@ -50,14 +50,13 @@ import io.micronaut.web.router.UriRouteMatch;
 import io.reactivex.Flowable;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 
@@ -114,6 +113,10 @@ public class ExpandedGetResponseFilter implements HttpServerFilter {
     return Flowable.fromPublisher(chain.proceed(request))
         .doOnNext(
             res -> {
+              // we don't want to add expands to failed requests
+              if (res.status().getCode() > 299) {
+                return;
+              }
               if (request.getMethod().equals(HttpMethod.GET)
                   && request.getParameters().contains(EXPAND_PARAM_NAME)) {
                 String expands = request.getParameters().get(EXPAND_PARAM_NAME);
@@ -195,9 +198,14 @@ public class ExpandedGetResponseFilter implements HttpServerFilter {
         continue;
       }
 
+      Map<String, Object> variables = new HashMap<>(routeMatchCurrentResource.getVariableValues());
+
+      if (mustAddEntityId) {
+        variables.put("id", ((Identifiable) initialBody.getData()).getId());
+      }
+
       String targetUri =
-          UriPlaceholderReplacer.replacePlaceholders(
-              subResourceContract.getHref(), routeMatchCurrentResource);
+          UriPlaceholderReplacer.replacePlaceholders(subResourceContract.getHref(), variables);
 
       Optional<UriRouteMatch<Object, Object>> routeMatch = router.GET(targetUri);
 
@@ -210,21 +218,28 @@ public class ExpandedGetResponseFilter implements HttpServerFilter {
 
         Object bean = applicationContext.getBean(declaringType);
 
-        List<Object> values =
-            new ArrayList<>(routeMatchCurrentResource.getVariableValues().values());
+        // argument names in the right order
+        String[] argumentNames = executableMethod.getArgumentNames();
+        // arguments in the right order
+        Object[] argumentList =
+            Stream.of(argumentNames)
+                // terrible hack around limitations in REST contracts xRoute naming
+                .map(name -> variables.getOrDefault(name, variables.get("id")))
+                .toArray();
 
-        if (mustAddEntityId) {
-          values.add(((Identifiable) initialBody.getData()).getId());
+        try {
+
+          Object result = executableMethod.invoke(bean, argumentList);
+
+          Expand expandedData =
+              result instanceof Collection
+                  ? new CollectionExpand(expand, (Collection<ResourceModel>) result)
+                  : new EntityExpand(expand, (ResourceModel) result);
+
+          initialBody.getExpands().add(expandedData);
+        } catch (Exception e) {
+          log.debug("Exception caught while expanding subresource " + expand, e);
         }
-
-        Object result = executableMethod.invoke(bean, values.toArray());
-
-        Expand expandedData =
-            result instanceof Collection
-                ? new CollectionExpand(expand, (Collection<ResourceModel>) result)
-                : new EntityExpand(expand, (ResourceModel) result);
-
-        initialBody.getExpands().add(expandedData);
       }
     }
   }
@@ -270,20 +285,27 @@ public class ExpandedGetResponseFilter implements HttpServerFilter {
      *
      * @param uriWithPlaceholders URI template containing placeholders in path such as {@code
      *     {:country}}.
-     * @param uriRouteMatch URI that matches the template.
+     * @param variables a map from variable name to the contents to substitute
      * @return a string with all placeholders resolved.
      */
     public static String replacePlaceholders(
-        String uriWithPlaceholders, UriRouteMatch uriRouteMatch) {
+        String uriWithPlaceholders, Map<String, Object> variables) {
 
-      Map<String, Object> variableValues = uriRouteMatch.getVariableValues();
       StringBuilder sb = new StringBuilder(uriWithPlaceholders);
 
-      for (String argumentName : uriRouteMatch.getArgumentNames()) {
-        String regex = String.format("{:%s}", "id".equals(argumentName) ? "entity" : argumentName);
+      for (String argumentName : variables.keySet()) {
+        // the `id` argument maps to the `{:entity}` placeholder
+        String placeHolder =
+            String.format("{:%s}", "id".equals(argumentName) ? "entity" : argumentName);
 
-        int index = sb.indexOf(regex);
-        sb.replace(index, index + regex.length(), String.valueOf(variableValues.get(argumentName)));
+        int index = sb.indexOf(placeHolder);
+        if (index == -1) {
+          throw new RuntimeException(
+              String.format(
+                  "Could not find placeholder %s in %s", placeHolder, uriWithPlaceholders));
+        }
+        sb.replace(
+            index, index + placeHolder.length(), String.valueOf(variables.get(argumentName)));
       }
 
       return sb.toString();

--- a/rest-api-micronaut/src/test/groovy/ch/silviowangler/rest/micronaut/UriPlaceholderReplacerSpec.groovy
+++ b/rest-api-micronaut/src/test/groovy/ch/silviowangler/rest/micronaut/UriPlaceholderReplacerSpec.groovy
@@ -23,7 +23,6 @@
  */
 package ch.silviowangler.rest.micronaut
 
-import io.micronaut.web.router.UriRouteMatch
 import spock.lang.Specification
 
 import static ch.silviowangler.rest.micronaut.ExpandedGetResponseFilter.UriPlaceholderReplacer.replacePlaceholders
@@ -35,36 +34,21 @@ class UriPlaceholderReplacerSpec extends Specification {
 
     void "replace one placeholder placeholder"() {
 
-        given:
-        UriRouteMatch uriRouteMatch = Mock()
-
         when:
-        String result = replacePlaceholders('/v1/countries/{:entity}/cities/', uriRouteMatch)
+        String result = replacePlaceholders('/v1/countries/{:entity}/cities/', ['id': 'CHE'])
 
         then:
         result == '/v1/countries/CHE/cities/'
-
-        and:
-        1 * uriRouteMatch.getVariableValues() >> ['id': 'CHE']
-        1 * uriRouteMatch.getArgumentNames() >> ['id']
-        0 * _
     }
 
     void "replace several placeholders placeholder"() {
 
-        given:
-        UriRouteMatch uriRouteMatch = Mock()
-
         when:
-        String result = replacePlaceholders('/v1/countries/{:country}/cities/{:entity}/municipalities', uriRouteMatch)
+        String result = replacePlaceholders('/v1/countries/{:country}/cities/{:entity}/municipalities', ['id': 'ZH', 'country': 'CHE'])
 
         then:
         result == '/v1/countries/CHE/cities/ZH/municipalities'
 
-        and:
-        1 * uriRouteMatch.getVariableValues() >> ['id': 'ZH', 'country': 'CHE']
-        1 * uriRouteMatch.getArgumentNames() >> ['country', 'id']
-        0 * _
     }
 
 }


### PR DESCRIPTION
The expands logic needs to be more defensive and add the "id" variable in case of a collection expands

E.g. if one of the subresources would return a 404, we would get some Exception coming from the 
invoke() call, and it makes sense to ignore these and leave the expands empty (e.g. missing Nationality in the gesus project). This way the expansion of other subresources can continue

Also to call subresources of collections endpoints (e.g. /v/applications/<pin>/persons?expands=*)
we need to pass the id of the element of the collection to the subresource method. However the naming of the arguments depends on the xRoute of the subresource, so that's why we have to fix `id` as that parameter in the subresource xRoute

PS: this version is published as 2.0.22-FORK in the gesus artifactory