### PR TITLE
Fix for the plugin ID.

### DIFF
--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -18,8 +18,12 @@ bintray {
             released = new Date()
         }
     }
-
-    publications = ['MyPublication']
+    if (project.name != 'gradle-java-rest-api') {
+      publications = ['MyPublication']
+    }
+    else {
+      publications = ['MyPublication', 'restapiPluginMarkerMaven']
+    }
 }
 
 def pomConfig = {


### PR DESCRIPTION
You should just be able to make a re-deploy to bintray and see that it uploads the missing file to the directory: ch/silviowangler/restapi/ch.silviowangler.restapi.gradle.plugin